### PR TITLE
Oirat fixes

### DIFF
--- a/common/countries/Lhasa.txt
+++ b/common/countries/Lhasa.txt
@@ -1,10 +1,9 @@
 #Country Name: Please see filename.
 
 graphical_culture = asiangfx
+color = {173 77 210}
 
-color = { 173 77 210 }
-
-revolutionary_colors = { 170 70 200 }
+revolutionary_colors = {15 0 2}
 
 historical_idea_groups = {
 	quantity_ideas
@@ -35,8 +34,24 @@ historical_units = {
 }
 
 monarch_names = {
-	"Namgyal De #0" = 20
-	"Namkha Wangpo Phuntsog De #0" = 20
+	"Ngawang Lobsang Gyatso #0" = 20
+	"Sonam Gyatso #0" = 20
+	"Kelsang Gyatso #0" = 20
+	"Trinley Gyatso #0" = 20
+	"Phagpa Lodro Gyaltsen #0" = 20
+	"Jamyang Wangchuk #0" = 20
+	"Ngawang Tenzin #0" = 20
+	"Lobsang Trinley #0" = 20
+	"Tsongkhapa Wangpo #0" = 20
+	"Shakya Rinchen #0" = 20
+	"Shakya Gyaltsen #0" = 20
+	"Tri Namgyal Dragpa #0" = 20
+	"Tri Tenzing Wangpo #0" = 20
+	"Tri Dragpa Wangchuk #0" = 20
+	"Tri Nyima Wangchuk #0" = 20
+	"Tri Ralpachen #0" = 20
+	"Tri Yeshe Wangchuk #0" = 20
+	"Namkha Wangpo Phuntsog #0" = 20
 	"Namri Sanggye De #0" = 20
 	"Lobsang Rabten #0" = 20
 	"Phagspa Lha #0" = 20
@@ -44,19 +59,11 @@ monarch_names = {
 	"Jigten Wangchuk Pekar De #0" = 20
 	"Ngagi Wangchuk #0" = 20
 	"Namkha Wangchuk #0" = 20
-	"Tri Nyima Wangchuk #0" = 20
-	"Tri Dragpa Wangchuk #0" = 20
-	"Tri Namgyal Dragpa De #0" = 20
-	"Tri Trashi Dragpa De #0" = 20
-	"Pratapamalla #0" = 20
-	"Kalyanamalla #0" = 20
-	"Ajitamalla #0" = 20
-
-	"Kamala #0" = -1
-	"Indira #0" = -1
-	"Surah Palinyal #0" = -1
-	"Kunzang #0" = -1
-	"Deki Choden #0" = -1
+	"Jigten Wangchuk Pekar De #0" = 20
+	"Drolma Wangmo #0" = -1
+	"Pema Choden #0" = -1
+	"Jangchub Deki #0" = -1
+	"Tsering Lhamo #0" = -1
 }
 
 leader_names = {
@@ -70,17 +77,84 @@ leader_names = {
 	Wangdue
 	Wangdak
 	Phuntsok
+	Jamyang
+	Ngawang
+	Trinley
+	Pema
+	Yeshe
+	Lobsang
+	Dorje
+	Rinchen
+	Drakpa
+	Tenzin
+	Gyaltsen
+	Kunga
 }
 
 ship_names = {
-	Barkam
-	Dartsendo
-	Gyantse Gartse
-	Lhasa Lhotse
-	Makalu 
-	Nagqu Nyingchi Nedong
-	Pelbar
-	Qamdo
-	Shigatse Sakya
-	Tinggri
+    Barkam
+    Dartsendo
+    Gyantse
+    Gartse
+    Lhasa
+    Lhotse
+    Makalu
+    Nagqu
+    Nyingchi
+    Nedong
+    Pelbar
+    Qamdo
+    Shigatse
+    Sakya
+    Tinggri
+    Tashi Gyatso    
+    Ganden Drakkar
+    Dorje Phurba 
+    Tsenpo's Might
+    Chomolungma
+    Kailash Avenger
+    Potala’s Wrath
+    Gyalpo's Fury
+    Mahakala 
+    Samye Guardian
+    Snow Lion 
+    Mandala Storm
+    Druk Thunder
+    Golden Dharma
+    Bodhisattva’s Grace
+    Sera Avenger
+    Gyeltsen’s Resolve
+}
+
+army_names = {
+    "Dmag of the Snowlands" 
+    "Dmag of the Lotus Throne" 
+    "Dmag of the White Conch" 
+    "Druk Dmag"  
+    "Dmag of the Red Hat"
+    "Dmag of the Yellow Hat"
+    "Gyalpo Dmag"   
+    "Dmag of the Snow Lion"   
+    "Dmag of the Vajra"    
+    "Dmag of the Potala"
+    "Kakyong of the Three Jewels"
+    "Kakyong of the Mandala"
+    "Magchen of the Holy Land"
+    "Dmag of the Sacred Yak"   
+    "Kakyong of the Dharma Wheel"
+    "Dmag of the $PROVINCE$"
+}
+
+fleet_names = {
+    "Drutsok of the Snowlands"  
+    "Drutsok of the Dharma"    
+    "Drutsok of the Potala"     
+    "Dru Vajra"                
+    "Dru Mandala"        
+    "Drutsok of the White Yak"
+    "Drutsok of the Thunder Dragon"
+    "Drumig of the Conquering Dharma"
+    "Drutsok of the Sacred River"
+    "Drutsok of the Dalai Lama"
+    "Drutsok of the $PROVINCE$"
 }

--- a/common/estate_privileges/00_ab_india_privileges.txt
+++ b/common/estate_privileges/00_ab_india_privileges.txt
@@ -251,7 +251,7 @@ estate_tamil_guilds_draft_merchant_ships = {
 		NOT = { has_country_modifier = tamil_guilds_drafted_ships_timer }
 	}
 	on_revoked = {
-		add_trasury = -150
+		add_treasury = -150
 	}
 	on_invalid = { add_prestige = -5 }
 	on_granted = {
@@ -309,7 +309,7 @@ estate_tamil_guilds_draft_war_ships = {
 		is_at_war = no
 	}
 	on_revoked = {
-		add_trasury = -125
+		add_treasury = -125
 		remove_country_modifier = tamil_guilds_drafted_war_ships_timer
 	}
 	on_invalid = { add_prestige = -5 }

--- a/common/government_names/ab_india_government_names.txt
+++ b/common/government_names/ab_india_government_names.txt
@@ -1,0 +1,147 @@
+gph_realm_of_the_bodhisattva = {
+	trigger = {
+		has_reform = gph_realm_of_the_bodhisattva
+		tag = GPH
+	}
+	rank = {
+		1 = GPH_MONASTIC_REALM_RANK
+		2 = GPH_GANDEN_PHODRANG_RANK
+		3 = GPH_UNIVERSAL_DHARMA_REALM_RANK
+	}
+	ruler_male = {
+		1 = GPH_DALAI_LAMA
+		2 = GPH_DALAI_LAMA
+		3 = GPH_DALAI_LAMA
+	}
+	ruler_female = {
+		1 = GPH_DALAI_LAMA
+		2 = GPH_DALAI_LAMA
+		3 = GPH_DALAI_LAMA
+	}
+	heir_male = {
+		1 = GPH_RECOGNIZED_REINCARNATION
+		2 = GPH_RECOGNIZED_REINCARNATION
+		3 = GPH_RECOGNIZED_REINCARNATION
+	}
+	heir_female = {
+		1 = GPH_RECOGNIZED_REINCARNATION
+		2 = GPH_RECOGNIZED_REINCARNATION
+		3 = GPH_RECOGNIZED_REINCARNATION
+	}
+}
+
+gph_eternal_throne_of_the_chakravartin = {
+	trigger = {
+		has_reform = gph_eternal_throne_of_the_chakravartin
+		tag = GPH
+	}
+	rank = {
+		1 = GPH_MONASTIC_REALM_RANK
+		2 = GPH_GANDEN_PHODRANG_RANK
+		3 = GPH_UNIVERSAL_DHARMA_REALM_RANK
+	}
+	ruler_male = {
+		1 = GPH_CHAKRAVARTIN
+		2 = GPH_CHAKRAVARTIN
+		3 = GPH_CHAKRAVARTIN
+	}
+	ruler_female = {
+		1 = GPH_CHAKRAVARTIN
+		2 = GPH_CHAKRAVARTIN
+		3 = GPH_CHAKRAVARTIN
+	}
+	heir_male = {
+		1 = GPH_RECOGNIZED_REINCARNATION
+		2 = GPH_RECOGNIZED_REINCARNATION
+		3 = GPH_RECOGNIZED_REINCARNATION
+	}
+	heir_female = {
+		1 = GPH_RECOGNIZED_REINCARNATION
+		2 = GPH_RECOGNIZED_REINCARNATION
+		3 = GPH_RECOGNIZED_REINCARNATION
+	}
+}
+
+buddhist_theocracy = {
+	rank = {
+		1 = HOLY_PRINCIPALITY
+		2 = HOLY_STATE
+		3 = HOLY_EMPIRE
+	}
+	ruler_male = {
+		1 = LAMA
+		2 = TULKU
+		3 = GREAT_TULKU
+	}
+	ruler_female = {
+		1 = LAMA
+		2 = TULKU
+		3 = GREAT_TULKU
+	}
+	consort_male = {
+		1 = CONSORT
+		2 = CONSORT
+		3 = CONSORT
+	}
+	consort_female = {
+		1 = CONSORT
+		2 = CONSORT
+		3 = CONSORT
+	}
+	heir_male = {
+		1 = HEIR
+		2 = HEIR
+		3 = HEIR
+	}
+	heir_female = {
+		1 = HEIR_fem
+		2 = HEIR_fem
+		3 = HEIR_fem
+	}
+	trigger = {
+		OR = {
+			religion = buddhism			#Theravada
+			religion = vajrayana
+			religion = mahayana
+		}
+		government = theocracy
+		NOT = {
+			tag = GPH
+		}
+		NOT ={
+			is_subject_of_type = chakravartin_order
+		}
+	}
+}
+
+chakravartin_order_reform = {
+	trigger = {
+		has_reform = chakravartin_order_reform
+		is_subject_of_type = chakravartin_order
+	}
+	rank = {
+		1 = CHAKRAVARTIN_ORDER_DUCHY
+		2 = CHAKRAVARTIN_ORDER_REALM
+		3 = CHAKRAVARTIN_ORDER_DOMINION
+	}
+	ruler_male = {
+		1 = CHAKRAVARTIN_ORDER_ABBOT_COMMANDER
+		2 = CHAKRAVARTIN_ORDER_ABBOT_GENERAL
+		3 = CHAKRAVARTIN_ORDER_DHARMA_LORD
+	}
+	ruler_female = {
+		1 = CHAKRAVARTIN_ORDER_ABBESS_COMMANDER
+		2 = CHAKRAVARTIN_ORDER_ABBESS_GENERAL
+		3 = CHAKRAVARTIN_ORDER_DHARMA_MOTHER
+	}
+	heir_male = {
+		1 = CHAKRAVARTIN_ORDER_HEIR_DISCIPLE
+		2 = CHAKRAVARTIN_ORDER_HEIR_MILITANT_PROTEGE
+		3 = CHAKRAVARTIN_ORDER_HEIR_ANOINTED_SUCCESSOR
+	}
+	heir_female = {
+		1 = CHAKRAVARTIN_ORDER_HEIR_DISCIPLE
+		2 = CHAKRAVARTIN_ORDER_HEIR_MILITANT_PROTEGE
+		3 = CHAKRAVARTIN_ORDER_HEIR_ANOINTED_SUCCESSOR
+	}
+}

--- a/common/government_reforms/ab_india_chakravartin_order_subject_reforms.txt
+++ b/common/government_reforms/ab_india_chakravartin_order_subject_reforms.txt
@@ -1,0 +1,32 @@
+chakravartin_order_reform = {
+	icon = "chakravartin_order_reform"
+	allow_convert = no
+	allow_normal_conversion = no
+	lock_level_when_selected = yes
+	fixed_rank = 2
+	potential = {
+		is_subject_of_type = chakravartin_order
+		OR = {
+			religion = vajrayana
+			religion = mahayana
+			religion = maitreya
+			religion = buddhism
+		}
+	}
+	modifiers = {
+		monarch_military_power = 2
+		land_morale = 0.1
+		naval_morale = 0.1
+		army_tradition = 0.5
+		leader_land_shock = 1
+		leader_land_fire = 1
+		leader_land_manuever = 1
+		leader_siege = 1
+	}
+	conditional = {
+		heir = no
+		allow = {
+		}
+	}
+	rulers_can_be_generals = yes
+}

--- a/common/scripted_effects/ab_india_lha_scripted_effects.txt
+++ b/common/scripted_effects/ab_india_lha_scripted_effects.txt
@@ -237,34 +237,58 @@ lha_subjugate_oirat_friend = {
 		limit = {
 			still_buddies_with_drb = yes
 		}
-		lha_subjugate_oirat = {
-			oirat_tag = DRB
+		every_country = {
+			limit = {
+				is_or_was_tag = {
+					tag = DRB
+				}
+			}
+			save_global_event_target_as = oirat_friend
 		}
 	}
 	else_if = {
 		limit = {
 			still_buddies_with_kht = yes
 		}
-		lha_subjugate_oirat = {
-			oirat_tag = KHT
+		every_country = {
+			limit = {
+				is_or_was_tag = {
+					tag = KHT
+				}
+			}
+			save_global_event_target_as = oirat_friend
 		}
 	}
 	else_if = {
 		limit = {
 			still_buddies_with_trg = yes
 		}
-		lha_subjugate_oirat = {
-			oirat_tag = TRG
+		every_country = {
+			limit = {
+				is_or_was_tag = {
+					tag = TRG
+				}
+			}
+			save_global_event_target_as = oirat_friend
 		}
 	}
 	else_if = {
 		limit = {
 			still_buddies_with_oir = yes
 		}
-		lha_subjugate_oirat = {
-			oirat_tag = OIR
+		every_country = {
+			limit = {
+				is_or_was_tag = {
+					tag = OIR
+				}
+			}
+			save_global_event_target_as = oirat_friend
 		}
 	}
+	lha_subjugate_oirat = {
+		oirat_tag = event_target:oirat_friend
+	}
+	clear_global_event_target = oirat_friend
 }
 
 lha_maritime_guild_effect = {

--- a/common/scripted_triggers/ab_india_scripted_triggers.txt
+++ b/common/scripted_triggers/ab_india_scripted_triggers.txt
@@ -196,11 +196,13 @@ has_exempt_from_seize_land_for_estate_gya = {
 
 still_buddies_with_kht = {
 	has_country_flag = lha_kht_friend
-	AND = {
-		exists = KHT
+	any_country = {
+		is_or_was_tag = {
+			tag = KHT
+		}
 		OR = {
-			alliance_with = KHT
-			overlord_of = KHT
+			alliance_with = ROOT
+			is_subject_of = ROOT
 		}
 	}
 }
@@ -547,7 +549,7 @@ fund_pilgrimage_cost_trigger = {
 	}
 }
 
-empire_of_china_dismantled= {
+empire_of_china_dismantled = {
 	custom_trigger_tooltip = {
 		tooltip = empire_of_china_dismantled_tooltip
 		OR = {

--- a/common/triggered_modifiers/ab_india_lha_mission_triggered_modifiers.txt
+++ b/common/triggered_modifiers/ab_india_lha_mission_triggered_modifiers.txt
@@ -7,25 +7,59 @@ lha_oirat_friend = {
 			limit = {
 				has_country_flag = lha_kht_friend
 			}
-			alliance_with = KHT
+			any_country = {
+				is_or_was_tag = {
+					tag = KHT
+				}
+				OR = {
+					alliance_with = ROOT
+					is_subject_of = ROOT
+				}
+			}
 		}
 		else_if = {
 			limit = {
 				has_country_flag = lha_drb_friend
 			}
-			alliance_with = DRB
+			any_country = {
+				is_or_was_tag = {
+					tag = DRB
+				}
+				OR = {
+					alliance_with = ROOT
+					is_subject_of = ROOT
+				}
+			}
 		}
 		else_if = {
 			limit = {
 				has_country_flag = lha_trg_friend
 			}
-			alliance_with = TRG
+			any_country = {
+				is_or_was_tag = {
+					tag = TRG
+				}
+				OR = {
+					alliance_with = ROOT
+					is_subject_of = ROOT
+				}
+			}
 		}
 		else_if = {
 			limit = {
 				has_country_flag = lha_oir_friend
 			}
-			alliance_with = OIR
+			OIR = {
+				any_country = {
+					is_or_was_tag = {
+						tag = OIR
+					}
+					OR = {
+						alliance_with = ROOT
+						is_subject_of = ROOT
+					}
+				}
+			}
 		}
 	}
 	diplomatic_upkeep = 1
@@ -53,6 +87,5 @@ lha_gratitude_of_the_khmer = {
 	trigger = {
 		accepted_culture = khmer
 	}
-	
 	num_accepted_cultures = 1
 }

--- a/events/ab_india_LHA_events.txt
+++ b/events/ab_india_LHA_events.txt
@@ -554,8 +554,8 @@ country_event = {
 				who = ROOT
 				value = 5
 			}
-			set_country_flag = lha_oir_friend
 		}
+		set_country_flag = lha_oir_friend
 	}
 	option = {
 		name = ab_india_lha_events.13.e

--- a/localisation/AB_india_countries_l_english.yml
+++ b/localisation/AB_india_countries_l_english.yml
@@ -93,7 +93,9 @@
  STR_ADJ:0 "Sataran"
  BHI:0 "Bhingar"
  BHI_ADJ:0 "Bhingari"
- YAD:0 "Seuna" #Yadava
+ YAD:0 "Seuna"
+ GPH:0 "Ganden Phodrang"
+ GPH_ADJ:0 "Phodrangian"
  YAD_ADJ:0 "Seuna"
  NVS:0 "Navsari"
  NVS_ADJ:0 "Navsarian"
@@ -276,3 +278,7 @@
  ANURADHAPURA_RENAME_ADJ:0 "Anuradhapuran"
  JFN_CONFEDERACY_OF_EELAM:0 "Confederacy of Eelam"
  JFN_CONFEDERACY_OF_EELAM_ADJ:0 "Eelami"
+
+ ORS:0 "Order of the Rising Sun"
+ ORS_ADJ:0 "Japanese"
+ ORS_ADJ2:0 "Japanese"

--- a/localisation/AB_india_cultures_l_english.yml
+++ b/localisation/AB_india_cultures_l_english.yml
@@ -24,3 +24,7 @@
  kanauji:0 "Kanauji"        #Previously called Hindavi
  hindavi:0 "Hindavi"        #Unified Central Aryan culture
  eelami:0 "Eelami"
+ gya:0 "Gya"
+ koriya:0 "Koriya"
+ manju:0 "Manju"
+ sogpo:0 "Sog Po"


### PR DESCRIPTION
### common/countries/Lhasa.txt

- Fix revolutionary colors, (countries don't use RGB values for revolutionary colors, they use color code parameters for each stripe of their tricolor flag. You can see them [here](https://eu4.paradoxwikis.com/Template:Revolutionary_flag#Values))
- Add Tibetan name flavor for monarchs, units, ships, etc.+

### common/estate_privileges/00_ab_india_privileges.txt

- Fix typo with add_treasury effect

### common/government_names/ab_india_government_names.txt

- Add missing government names for GPH and Chakravartin Order subjects.

### common/government_reforms/ab_india_chakravartin_order_subject_reforms.txt

- Add missing government reform for Chakravartin order.

### localisation/AB_india_countries_l_english.yml

- Add missing localization for GPH and ORS.

### localisation/AB_india_cultures_l_english.yml

- Add missing localization for Tibetanized cultures.

### Everything Else

- Refactored code behind checking if the Oirat tribe is still your friend. Now it doesn't matter what tag they change into, the code will be able to check if they were originally the country you allied. 
- Changed the triggers so it's fine if they're your subject when performing the checks because the AI is stupid and likes to get into wars where you can't help them and then they get gobbled up by their neighbors, so sometimes you have to go in there and release them from the dead.
